### PR TITLE
bugfix: bbframe duplicated on event PLAYER_ENTERING_WORLD

### DIFF
--- a/src/events/consumer/playerConsumer.lua
+++ b/src/events/consumer/playerConsumer.lua
@@ -1,4 +1,6 @@
-PlayerEventConsumer = {}
+PlayerEventConsumer = {
+    alreadyInitialized = false
+}
 
 PlayerEventConsumer.AllowedEvents = {
     PLAYER_ENTERING_WORLD = true
@@ -6,8 +8,9 @@ PlayerEventConsumer.AllowedEvents = {
 
 PlayerEventConsumer.Execute = function(self, event)
     
-    if (self.AllowedEvents[event] == nil) then return end
+    if (self.AllowedEvents[event] == nil or self.alreadyInitialized == true) then return end
     
     PlayerHealth:BuildElements()
     PlayerPower:BuildElements()
+    self.alreadyInitialized = true
 end

--- a/src/events/consumer/targetConsumer.lua
+++ b/src/events/consumer/targetConsumer.lua
@@ -1,4 +1,6 @@
-TargetEventConsumer = {}
+TargetEventConsumer = {
+    alreadyInitialized = false
+}
 
 TargetEventConsumer.AllowedEvents = {
     PLAYER_ENTERING_WORLD = true
@@ -7,8 +9,14 @@ TargetEventConsumer.AllowedEvents = {
 TargetEventConsumer.Execute = function(self, event)
     
     if (self.AllowedEvents[event] == nil) then return end
+    if (self.alreadyInitialized == true) then
+        TargetHealth.frame:Hide()
+        TargetPower.frame:Hide()
+        TargetInfo.frame:Hide()
+    end
 
     TargetHealth:BuildElements()
     TargetPower:BuildElements()
     TargetInfo:BuildElements()
+    self.alreadyInitialized = true
 end


### PR DESCRIPTION
event is fired not only when login in but also when teleporting, using hearthstone, portals, etc

cleanup and refactoring TargetInfo